### PR TITLE
implement config.sh for inside iso

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 out/*
 airootfs/root/.ssh/authorized_keys
-airootfs/root/customize_airootfs.sh
 config.sh

--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ LARS is an [Arch Linux](https://www.archlinux.org/) based live system intended t
 
 ## How to use
 You check out this project on your local computer, modify the config to your needs and create the ISO. It will than be copied to your DHCP server where the ISO will be extracted.
-* Copy extract_archiso to your DHCP server
-* Copy config.sh.example to config.sh
-* Copy airootfs/root/customize_airootfs.sh.example to airootfs/root/customize_airootfs.sh
-* Update the variables to your needs (see [configuration](#configuration))
-* run rebuild_and_copy.sh
+* Copy `extract_archiso.sh` to your DHCP server
+* Copy `config.sh.example` to `config.sh`
+* Update the variables to your needs (see[configuration](#configuration))
+* run `rebuild_and_copy.sh`
 
 ---
 
@@ -26,8 +25,10 @@ Every configuration option for the deployment is listed in `config.sh`:
 * DHCP_USER - ssh user to copy the images
 * DHCP_PATH - where to place the created ISO
 * DHCP_EXTRACT - where is the extract_archiso.sh located on the DHCP server
+* ISO_MIRROR - URL to an arch mirror that will be written to the pacman config
+* ISO_NFSSERVER - NFS server that serves the installimage itself and images
 
-Everything that we configure inside of the iso is configured in airootfs/root/customize_airootfs.sh, important points are:
-* we point to an internal mirror
-* add NFS mount points for installimage
-* use systemd-networkd for dhcp instead of dhcpcd
+Everything that we configure inside of the iso is configured in airootfs/root/customize_airootfs.sh, important points are (there should be no need to modify this file!):
+* we point to an internal mirror if available
+* add NFS mount points for installimage if NFS server is available
+* use systemd-networkd with dhcp instead of dhcpcd

--- a/airootfs/root/.bash_profile
+++ b/airootfs/root/.bash_profile
@@ -1,1 +1,2 @@
+. ~/.automated_script.sh
 [[ -r ~/.bashrc ]] && . ~/.bashrc

--- a/airootfs/root/customize_airootfs.sh
+++ b/airootfs/root/customize_airootfs.sh
@@ -4,7 +4,19 @@
 # modified by bastelfreak
 # based on work from Bluewind and foxxx0
 ##
+
+# get our config
+config='/root/config.sh'
+if [ -x "$config" ]; then
+  . /root/config.sh
+else
+  exit 1
+fi
+
 set -e -u
+
+# get our config
+. /root/config.sh
 
 # english language and german keyboard layout
 sed -i 's/#\(en_US\.UTF-8\)/\1/' /etc/locale.gen
@@ -16,7 +28,9 @@ ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 usermod -s /usr/bin/bash root
 chmod 700 /root
 
-echo -en 'Server = http://ownmirror.local/$repo/os/$arch\n' > /etc/pacman.d/mirrorlist
+if [ -n "$ISO_MIRROR" ]; then
+  echo "Server = $ISO_MIRROR" > /etc/pacman.d/mirrorlist
+fi
 
 sed -i 's/#\(PermitRootLogin \).\+/\1yes/' /etc/ssh/sshd_config
 sed -i 's/#\(Storage=\)auto/\1volatile/' /etc/systemd/journald.conf
@@ -29,19 +43,25 @@ systemctl enable pacman-init.service choose-mirror.service systemd-networkd.serv
 systemctl set-default multi-user.target
 
 # they are broken and nobody needs them
-pacman -Rdd --noconfirm openresolv netctl dhcpcd
+pacman -Rns --noconfirm openresolv netctl dhcpcd
 
 # populate trust information
 trust extract-compat
 
+# add installimage NFS mounts
+if [ -n "$ISO_NFSSERVER" ]; then
+  echo "${ISO_NFSSERVER}:/srv/nfs/installimage /root/.installimage nfs ro 0 0" >> /etc/fstab
+  echo "${ISO_NFSSERVER}:/srv/nfs/images /root/images nfs ro 0 0" >> /etc/fstab
+  mkdir -p /root/{images,.installimage}
+fi
+
 # update package information
 pacman -Syy
 pkgfile --update
+
+# remove config, could contain sensitive information and we don't want to ship it in the ISO
+rm "$config"
+
+# use the resolv.conf from systemd-resolved.service
 umount /etc/resolv.conf
 ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-
-# add installimage NFS mounts
-echo 'nfsserver.local:/srv/nfs/installimage /root/.installimage nfs ro 0 0' >> /etc/fstab
-echo 'nfsserver.local:/srv/nfs/images /root/images nfs ro 0 0' >> /etc/fstab
-mkdir -p /root/images
-mkdir -p /root/.installimage

--- a/config.sh.example
+++ b/config.sh.example
@@ -3,3 +3,6 @@ DHCP_SERVER='dhcp01.local'
 DHCP_USER='root'
 DHCP_PATH='/var/www/archrescue/'
 DHCP_EXTRACT='/usr/local/bin/extract_archiso'
+
+ISO_MIRROR='http://internal-mirror.local/$repo/os/$arch'
+ISO_NFSSERVER='10.30.7.40'

--- a/rebuild_and_copy.sh
+++ b/rebuild_and_copy.sh
@@ -5,10 +5,20 @@
 # based on a script by Bluewind
 ##
 
-. config.sh
+config='config.sh'
+
+if [ -x "$config" ]; then
+  . config.sh
+else
+  exit 1
+fi
+
+# we need to place the set under the exit
+# it would ignore it because it's in an if/fi statement
 set -e
 umask 022
 
+cp config.sh airootfs/root/
 rm -rf work
 ./build.sh -v
 rm -rf work


### PR DESCRIPTION
this updates the scripts and documentation about the usage of config.sh.
It will be copied into our ISO directory, the customize_airootfs.sh
script will source it and use the variables if available.

this commit also updates the .bash_profile to run the .automated_script.sh.
