### PR TITLE
support unattended installimage runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 out/*
 airootfs/root/.ssh/authorized_keys
 airootfs/root/config
-config.sh
+config_*.sh
 work

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You check out this project on your local computer, modify the config to your nee
 
 ## Configuration
 Every configuration option for the deployment is listed in our two config files.
-`config_build.sh`
+`config_build.sh` is used during the build process from [rebuild_and_copy](https://github.com/virtapi/LARS/blob/master/rebuild_and_copy.sh) (outside of the ISO) and from [customize_airootfs.sh](https://github.com/virtapi/LARS/blob/master/airootfs/root/customize_airootfs.sh) and deleted afterwards. It won't be included in the ISO (so you could place sensitive information here)!
 * DHCP_SERVER - FQDN/IP of your DHCP/Image Server
 * DHCP_USER - ssh user to copy the images
 * DHCP_PATH - where to place the created ISO
@@ -30,7 +30,7 @@ Every configuration option for the deployment is listed in our two config files.
 * ISO_MIRROR - URL to an arch mirror that will be written to the pacman config
 * ISO_NFSSERVER - NFS server that serves the installimage itself and images
 
-`config_live.sh`
+`config_live.sh` is used from [start_installimage](https://github.com/virtapi/LARS/blob/master/scripts/start_installimage) during the usage of the ISO itself. This config file helps the script to find the correct place for installimage configs. This config file is visible to every customer that uses the rescue system so take about the data you put into it.
 * CONFIG_PROTO - protocol for connection to the installimage server
 * CONFIG_SERVER - IP/FQDN for connection to the installimage server
 * CONFIG_PATH - URL subdir

--- a/README.md
+++ b/README.md
@@ -7,20 +7,22 @@ LARS is an [Arch Linux](https://www.archlinux.org/) based live system intended t
 ## Contents
 + [How to use](#how-to-use)
 + [Configuration](#configuration)
-
++ [Using the installimage](#using-the-installimage)
 ---
 
 ## How to use
 You check out this project on your local computer, modify the config to your needs and create the ISO. It will than be copied to your DHCP server where the ISO will be extracted.
 * Copy `extract_archiso.sh` to your DHCP server
-* Copy `config.sh.example` to `config.sh`
+* Copy `config_buil.sh.example` to `config_build.sh`
+* Copy `config_live.sh.example` to `config_live.sh`
 * Update the variables to your needs (see[configuration](#configuration))
 * run `rebuild_and_copy.sh`
 
 ---
 
 ## Configuration
-Every configuration option for the deployment is listed in `config.sh`:
+Every configuration option for the deployment is listed in our two config files.
+`config_build.sh`
 * DHCP_SERVER - FQDN/IP of your DHCP/Image Server
 * DHCP_USER - ssh user to copy the images
 * DHCP_PATH - where to place the created ISO
@@ -28,7 +30,18 @@ Every configuration option for the deployment is listed in `config.sh`:
 * ISO_MIRROR - URL to an arch mirror that will be written to the pacman config
 * ISO_NFSSERVER - NFS server that serves the installimage itself and images
 
+`config_live.sh`
+* CONFIG_PROTO - protocol for connection to the installimage server
+* CONFIG_SERVER - IP/FQDN for connection to the installimage server
+* CONFIG_PATH - URL subdir
+* CONFIG_FILE - the file itself
+
 Everything that we configure inside of the iso is configured in airootfs/root/customize_airootfs.sh, important points are (there should be no need to modify this file!):
 * we point to an internal mirror if available
 * add NFS mount points for installimage if NFS server is available
 * use systemd-networkd with dhcp instead of dhcpcd
+
+---
+
+## Using the installimage
+You can start the installimage with the [start_installimage](https://github.com/virtapi/LARS/blob/master/scripts/start_installimage) script. This will source the `config_live.sh` file and try to download a normal installimage autoconfig file, if this fails it tries to download a json hash which will be converted into the needed format. After that, the installimage starts in a screen session and reboots if everything worked well. You can do a fully automated installatio if you attach `script=/usr/local/bin/start_installimage` to the PXE kernel cmdline.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You check out this project on your local computer, modify the config to your nee
 
 ## Configuration
 Every configuration option for the deployment is listed in our two config files.
-`config_build.sh` is used during the build process from [rebuild_and_copy](https://github.com/virtapi/LARS/blob/master/rebuild_and_copy.sh) (outside of the ISO) and from [customize_airootfs.sh](https://github.com/virtapi/LARS/blob/master/airootfs/root/customize_airootfs.sh) and deleted afterwards. It won't be included in the ISO (so you could place sensitive information here)!
+`config_build.sh` is used during the build process from [rebuild_and_copy](https://github.com/virtapi/LARS/blob/master/rebuild_and_copy.sh) (outside of the ISO) and from [customize_airootfs.sh](https://github.com/virtapi/LARS/blob/master/airootfs/root/customize_airootfs.sh) (inside the ISO chroot). It will be  temporarily copied into the build directory and deleted afterwards. The copy won't be included in the ISO (so you could place sensitive information here)!
 * DHCP_SERVER - FQDN/IP of your DHCP/Image Server
 * DHCP_USER - ssh user to copy the images
 * DHCP_PATH - where to place the created ISO
@@ -30,7 +30,7 @@ Every configuration option for the deployment is listed in our two config files.
 * ISO_MIRROR - URL to an arch mirror that will be written to the pacman config
 * ISO_NFSSERVER - NFS server that serves the installimage itself and images
 
-`config_live.sh` is used from [start_installimage](https://github.com/virtapi/LARS/blob/master/scripts/start_installimage) during the usage of the ISO itself. This config file helps the script to find the correct place for installimage configs. This config file is visible to every customer that uses the rescue system so take about the data you put into it.
+`config_live.sh` is used from [start_installimage](https://github.com/virtapi/LARS/blob/master/scripts/start_installimage) during the usage of the ISO itself. This config file helps the script to find the correct place for installimage configs. This config file is visible to every customer that uses the rescue system so take care about the data you put into it.
 * CONFIG_PROTO - protocol for connection to the installimage server
 * CONFIG_SERVER - IP/FQDN for connection to the installimage server
 * CONFIG_PATH - URL subdir

--- a/airootfs/root/customize_airootfs.sh
+++ b/airootfs/root/customize_airootfs.sh
@@ -8,16 +8,15 @@
 # get our config
 config='/root/config.sh'
 if [ -n "$config" ] && [ -e "$config" ]; then
-  . /root/config.sh
+  # source and remove config, could contain sensitive information and we don't want to ship it in the ISO
+  . "${config}"
+  rm "${config}"
 else
   echo "Error: ${config} file isn't available"
   exit 1
 fi
 
 set -e -u
-
-# get our config
-. /root/config.sh
 
 # english language and german keyboard layout
 sed -i 's/#\(en_US\.UTF-8\)/\1/' /etc/locale.gen
@@ -69,9 +68,6 @@ GECOS="$(awk -F: '/^root/ {print $3":"$4":"$5":"$6":"$7":"$8":"}' /etc/shadow)"
 echo "root:${ISO_ROOTHASH}:${GECOS}" > /etc/shadow
 cat /tmp/shadow.tmp >> /etc/shadow
 rm /tmp/shadow.tmp
-
-# remove config, could contain sensitive information and we don't want to ship it in the ISO
-rm "$config"
 
 # use the resolv.conf from systemd-resolved.service
 umount /etc/resolv.conf

--- a/config_build.sh.example
+++ b/config_build.sh.example
@@ -1,9 +1,16 @@
 #!/bin/bash
+
+##
+# Created by Tim Meusel
+##
+
+# variables used for handling the ISO
 DHCP_SERVER='dhcp01.local'
 DHCP_USER='root'
 DHCP_PATH='/var/www/archrescue/'
 DHCP_EXTRACT='/usr/local/bin/extract_archiso'
 
+# variables used inside of the ISO during the build
 ISO_MIRROR='http://internal-mirror.local/$repo/os/$arch'
 ISO_NFSSERVER='10.30.7.40'
 ISO_ROOTHASH='*'

--- a/config_live.sh.example
+++ b/config_live.sh.example
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+##
+# created by Tim Meusel
+##
+
+# these variables will be used from the installimage
+CONFIG_PROTO='http'
+CONFIG_SERVER='10.30.7.40'
+CONFIG_PATH='installimage_configs'
+CONFIG_FILE='config.cfg'

--- a/ext_scripts/.gitignore
+++ b/ext_scripts/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/packages.both
+++ b/packages.both
@@ -55,3 +55,4 @@ moreutils
 dfc
 mdadm
 ccze
+screen

--- a/rebuild_and_copy.sh
+++ b/rebuild_and_copy.sh
@@ -27,11 +27,7 @@ cp "$config_build" airootfs/root/
 
 # copy the config, needed after booting the ISO
 mkdir -p airootfs/usr/local/bin/
-cp "${config_live}" airootfs/usr/local/bin/
-cp scripts/* airootfs/usr/local/bin/
-if [ $(ls -A ext_scripts/* 2>> /dev/null) ]; then
-  cp ext_scripts/* airootfs/usr/local/bin/
-fi
+rsync -a ext_scripts/ scripts/ "${config_live}" airootfs/usr/local/bin/
 
 # clean builddir, build the ISO, clean it again
 rm -rf work

--- a/rebuild_and_copy.sh
+++ b/rebuild_and_copy.sh
@@ -5,29 +5,45 @@
 # based on a script by Bluewind
 ##
 
-config='config.sh'
+config_build='config_build.sh'
+config_live='config_live.sh'
 
-if [ -n "$config" ] && [ -e "$config" ]; then
-  . config.sh
-else
-  echo "Error: ${config} file isn't available"
-  exit 1
-fi
+for file in "$config_build" "$config_live"; do
+  if [ ! -e "$file" ]; then
+    echo "Error: ${file} file isn't available"
+    exit 1
+  fi
+done
+
+. "$config_build"
 
 # we need to place the set under the exit
 # it would ignore it because it's in an if/fi statement
 set -e
 umask 022
 
-cp config.sh airootfs/root/
+# copy the config because we need it later during build inside of the ISO
+cp "$config_build" airootfs/root/
+
+# copy the config, needed after booting the ISO
+mkdir -p airootfs/usr/local/bin/
+cp "${config_live}" airootfs/usr/local/bin/
+cp scripts/* airootfs/usr/local/bin/
+if [ $(ls -A ext_scripts/* 2>> /dev/null) ]; then
+  cp ext_scripts/* airootfs/usr/local/bin/
+fi
+
+# clean builddir, build the ISO, clean it again
 rm -rf work
 ./build.sh -v
 rm -rf work
 
+# determine the name of the latest ISO
 unset -v latest
 for file in out/archlinux-*.iso; do
 	[[ $file -nt $latest ]] && latest=$file
 done
 
+# copy and extract the ISO
 rsync -tP "$latest" -e ssh "${DHCP_USER}@${DHCP_SERVER}:${DHCP_PATH}"
 ssh "${DHCP_USER}@${DHCP_SERVER}" "${DHCP_EXTRACT} ${DHCP_PATH}${latest##*/}"

--- a/scripts/start_installimage
+++ b/scripts/start_installimage
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+##
+# created by Tim Meusel
+# with help from Silvio Knizek
+##
+
+# this script will download our installimage config
+
+# get our config
+config='/usr/local/bin/config_live.sh'
+if [ -n "$config" ] && [ -e "$config" ]; then
+  . "${config}"
+else
+  echo "Error: ${config} file isn't available"
+  exit 1
+fi
+
+set -e -u
+
+#mac="$(ifdata -ph eth0 | awk '{gsub(":",""); print tolower($1)}')"
+mac=$(awk 'BEGIN {FS="="; RS=" ";} { if ($1 ~ /BOOTIF/) {gsub(/^[^-]+-/, "", $2); gsub(/-/, "", $2); print toupper($2)}}' /proc/cmdline)
+
+url="${CONFIG_PROTO}://${CONFIG_SERVER}/${CONFIG_PATH}/${mac}/${CONFIG_FILE}.cfg"
+
+wget "${url}" --retry-connrefused -q -O /root/config.cfg
+if [ $? != 0 ]; then
+  url="${CONFIG_PROTO}://${CONFIG_SERVER}/${CONFIG_PATH}/${mac}/${CONFIG_FILE}.json"
+  wget "${url}" --retry-connrefused -q -O /root/config.json
+  if [ $? != 0 ]; then
+    echo "failed to download normal config and json config"
+    exit 1
+  else
+    # here we can do Robin Martinjaks python magic to convert the json into the installimage format
+    true;
+  fi
+fi
+
+# start installimage with our config
+/root/.installimage/installimage.in_screen -c config.cfg -a


### PR DESCRIPTION
this adds a few helper scripts that add support for our installimage. We now have two config file, one for the ISO build itself and one for our live system. the start_installimage script can download a normal or json encoded config and than starts the installimage. This will implement [issue 8](https://github.com/virtapi/LARS/issues/8).
